### PR TITLE
Support invokation via symlink

### DIFF
--- a/nix-debug-shell
+++ b/nix-debug-shell
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-dir=$(readlink -f $(dirname "$0"))
+dir=$(dirname $(readlink -f "$0"))
 
 declare -a args
 


### PR DESCRIPTION
My `~/bin/nix-debug-shell` links to `nix-debug-shell` script, and this change is needed to support that.